### PR TITLE
fix: grant android post notifications permission for api < 33

### DIFF
--- a/src/event-manager/push-manager/PushNotificationPermission.ts
+++ b/src/event-manager/push-manager/PushNotificationPermission.ts
@@ -48,9 +48,9 @@ export const PushNotificationPermission = async ({
   }
 
   if (Platform.OS === 'android') {
-    const authStatus = await PermissionsAndroid.request(
-      PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS!
-    );
+    const authStatus = Platform.Version >= 33
+      ? await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS!)
+      : PermissionsAndroid.RESULTS.GRANTED;
 
     if (authStatus === PermissionsAndroid.RESULTS.GRANTED) {
       await HandlePlatformSpecificPushFlow({


### PR DESCRIPTION
Burası android api 33 altında bir cihazla test edildiğinde never_ask_again sonucu verdiği için push akışına girmemektedir. Çözüm olarak api 33 altına grant vermek gerekli.